### PR TITLE
PC url도 받을 수 있도록 수정

### DIFF
--- a/bizm.gemspec
+++ b/bizm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bizm'
-  s.version     = '2.2.1'
+  s.version     = '2.3.0'
   s.summary     = 'BizM client for ruby'
   s.description = 'BizM client for ruby sending Kakao AlimTalk'
   s.authors     = ['Soohyeon Lee', 'Gyumin Sim']

--- a/lib/bizm.rb
+++ b/lib/bizm.rb
@@ -44,11 +44,14 @@ class BizM
     end
 
     buttons.each_with_index do |button, index|
-      data["button#{index + 1}".to_sym] = {
+      button_data = {
         name: button[:name],
         type: 'WL',
-        url_mobile: button[:url]
+        url_mobile: button[:url],
       }
+      button_data.merge!(url_pc: button[:url_pc]) if button[:url_pc].present?
+
+      data["button#{index + 1}".to_sym] = button_data
     end
 
     if msg_sms && sms_sender


### PR DESCRIPTION
기존의 bizm-ruby에는 PC-URL 링크를 보낼 수 없었습니다.
PC-URL을 선택적으로 보낼 수 있도록 수정했습니다.

https://app.swit.io/privatenote/channel/211101064528406Ossx/chat?msg_view=230227080480mf5U4sS