### PR TITLE
Send payload for `cancel_reserved` API via form data instead of JSON

### DIFF
--- a/bizm.gemspec
+++ b/bizm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bizm'
-  s.version     = '2.3.0'
+  s.version     = '2.3.1'
   s.summary     = 'BizM client for ruby'
   s.description = 'BizM client for ruby sending Kakao AlimTalk'
   s.authors     = ['Soohyeon Lee', 'Gyumin Sim']

--- a/lib/bizm.rb
+++ b/lib/bizm.rb
@@ -77,7 +77,6 @@ class BizM
     uri = URI.parse('https://alimtalk-api.bizmsg.kr/v2/sender/cancel_reserved')
 
     header = {
-      'Content-type': 'application/json;charset=UTF-8',
       'userid': @user_id
     }
     data = {
@@ -85,7 +84,7 @@ class BizM
       profile: @profile,
     }
     request = Net::HTTP::Post.new(uri.path, header)
-    request.body = data.to_json
+    request.set_form_data(data)  # This API doesn't accept JSON body
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true


### PR DESCRIPTION
비즈엠의 `/v2/sender/cancel_reserved` API는 JSON body를 받지 않습니다. form data로 payload를 전송해, API가 제대로 동작하도록 고칩니다.

개발 문서를 보면 상당히 교묘하게 되어있는데, POST body로 JSON을 받는 곳에서는 "body"라고 명확히 명시를 하지만 그렇지 않은 곳에서는 그냥 "parameter"라고 되어있습니다.

로컬에서 API 요청 테스트한 결과:

- JSON으로 보낸 경우
<img width="651" alt="스크린샷 2024-01-12 12 26 44" src="https://github.com/privatenote/bizm-ruby/assets/121408862/ada9ce1d-356c-4a04-ab6b-c07b42d161b1">

- form data로 보낸 경우
<img width="651" alt="스크린샷 2024-01-12 12 26 53" src="https://github.com/privatenote/bizm-ruby/assets/121408862/f48cbd04-5fa4-4de5-bf30-017a77430fd6">
