### PR TITLE
알림톡 타입 파라미터 추가

### DIFF
--- a/bizm.gemspec
+++ b/bizm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bizm'
-  s.version     = '2.3.1'
+  s.version     = '2.4.0'
   s.summary     = 'BizM client for ruby'
   s.description = 'BizM client for ruby sending Kakao AlimTalk'
   s.authors     = ['Soohyeon Lee', 'Gyumin Sim']

--- a/lib/bizm.rb
+++ b/lib/bizm.rb
@@ -13,6 +13,7 @@ class BizM
     phone:,
     msg:,
     tmpl_id:,
+    message_type: 'AT',
     reserve_dt: '00000000000000',
     button_name: nil,
     button_url: nil,
@@ -28,7 +29,7 @@ class BizM
     }
 
     data = {
-      message_type: 'AT',
+      message_type: message_type,
       phn: phone,
       profile: @profile,
       reserveDt: reserve_dt,


### PR DESCRIPTION
이미지 알림톡은 message_type을 'AI'로 설정해야 합니다.
이를 위해 bizm gem이 message_type을 파라미터로 받을 수 있도록 수정합니다.

로컬에서 확인하였습니다.
<img width="322" alt="image" src="https://github.com/privatenote/bizm-ruby/assets/36955431/3a0e2e3f-7e22-47a0-9bfb-7c2594c72fcc">
