### PR TITLE
아이템 리스트 property 추가

### DIFF
--- a/bizm.gemspec
+++ b/bizm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bizm'
-  s.version     = '2.4.0'
+  s.version     = '2.5.0'
   s.summary     = 'BizM client for ruby'
   s.description = 'BizM client for ruby sending Kakao AlimTalk'
   s.authors     = ['Soohyeon Lee', 'Gyumin Sim']

--- a/lib/bizm.rb
+++ b/lib/bizm.rb
@@ -18,6 +18,7 @@ class BizM
     button_name: nil,
     button_url: nil,
     buttons: [],
+    item: nil,
     msg_sms: nil,
     sms_sender: nil
   )
@@ -34,7 +35,8 @@ class BizM
       profile: @profile,
       reserveDt: reserve_dt,
       msg: msg,
-      tmplId: tmpl_id
+      tmplId: tmpl_id,
+      item: item
     }
 
     if buttons.empty? && !button_name.nil?

--- a/lib/bizm.rb
+++ b/lib/bizm.rb
@@ -18,25 +18,22 @@ class BizM
     button_name: nil,
     button_url: nil,
     buttons: [],
-    item: nil,
+    items: nil,
+    header: nil,
     msg_sms: nil,
     sms_sender: nil
   )
     uri = URI.parse('https://alimtalk-api.bizmsg.kr/v2/sender/send')
-
-    header = {
-      'Content-type': 'application/json;charset=UTF-8',
-      'userid': @user_id
-    }
 
     data = {
       message_type: message_type,
       phn: phone,
       profile: @profile,
       reserveDt: reserve_dt,
+      header: header,
+      items: items,
       msg: msg,
-      tmplId: tmpl_id,
-      item: item
+      tmplId: tmpl_id
     }
 
     if buttons.empty? && !button_name.nil?
@@ -63,7 +60,12 @@ class BizM
       data[:smsSender] = sms_sender
     end
 
-    request = Net::HTTP::Post.new(uri.path, header)
+    request_header = {
+      'Content-type': 'application/json;charset=UTF-8',
+      'userid': @user_id
+    }
+
+    request = Net::HTTP::Post.new(uri.path, request_header)
     request.body = [data].to_json
 
     http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
알림톡 메세지 타입 중 '아이템 리스트' 속성이 있습니다.

이를 사용하기 위해서는 API를 전송할 때 item property를 추가할 수 있어야 합니다.

로컬에서 정상적으로 메시지를 전송할 수 있는지 확인했습니다.

<img width="377" alt="스크린샷 2024-05-20 오전 10 34 50" src="https://github.com/privatenote/bizm-ruby/assets/36955431/2052ca1e-3f9e-4b4b-a8eb-eb3cad2ba41b">
